### PR TITLE
Implement ash deposition handling and transfer to surface DOC/DON - v2

### DIFF
--- a/rhessys/cn/compute_fire_effects.c
+++ b/rhessys/cn/compute_fire_effects.c
@@ -161,6 +161,23 @@ void compute_fire_effects(
 
         patch[0].litterc_burned = litter_c_consumed;//new NREN
 
+        if (command_line[0].ash_deposition_flag == 1){
+			// if (command_line[0].verbose_flag == -7) {
+			// 	printf("Starting - Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_C_pool);
+			// 	printf("Starting - Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_N_pool);
+			// }
+			patch[0].ash_C_pool += fmax(0.0, litter_c_consumed);
+			// don't need this calculation otherwise, so doing it here for ash dep only
+            patch[0].ash_N_pool += fmax(0.0, patch[0].litter_ns.litr1n * fire_loss.loss_litr1n +
+                                                 patch[0].litter_ns.litr2n * fire_loss.loss_litr2n +
+                                                 patch[0].litter_ns.litr3n * fire_loss.loss_litr3n +
+                                                 patch[0].litter_ns.litr4n * fire_loss.loss_litr4n);
+            // if (command_line[0].verbose_flag == -7) {
+			// 	printf("Litter - Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_C_pool);
+			// 	printf("Litter - Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_N_pool);
+			// }
+		}
+
         update_litter_soil_mortality(
              &(patch[0].cdf),
              &(patch[0].ndf),
@@ -298,6 +315,14 @@ void compute_fire_effects(
                 canopy_target[0].cs.cwdc -= canopy_target[0].fe.m_cwdc_to_atmos;
                 canopy_target[0].ns.cwdn -= canopy_target[0].fe.m_cwdn_to_atmos;
 
+                if (command_line[0].ash_deposition_flag == 1){
+                    patch[0].ash_C_pool += fmax(0.0, canopy_target[0].fe.m_cwdc_to_atmos);
+                    patch[0].ash_N_pool += fmax(0.0, canopy_target[0].fe.m_cwdn_to_atmos);
+                    // if (command_line[0].verbose_flag == -7) {
+                    //     printf("CWD - Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_C_pool);
+                    //     printf("CWD - Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_N_pool);
+                    // }
+                }
 
             /*--------------------------------------------------------------*/
             /* Calculate fire effects when target canopy is tall            */
@@ -535,6 +560,36 @@ void compute_fire_effects(
             /* Determine the proportion of total target canopy carbon that is consumed by fire */
                 canopy_target[0].fe.canopy_target_prop_c_consumed = canopy_target[0].fe.canopy_target_prop_mort  * canopy_target[0].fe.canopy_target_prop_mort_consumed;
 
+                /*----------------------------------------------------------------------------------------*/
+                /* Add C consumed to ash deposition storage         */
+                /*----------------------------------------------------------------------------------------*/
+                // do this before any changes to the baseline stores
+                if (command_line[0].ash_deposition_flag == 1){
+                    patch[0].ash_C_pool += fmax(0.0, (canopy_target[0].cs.leafc * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].cs.frootc * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].cs.live_stemc * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].cs.dead_stemc * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].cs.cpool * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].cs.live_crootc * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].cs.dead_crootc * canopy_target[0].fe.canopy_target_prop_c_consumed));
+                    // Could include stores+transfers - if adding, it would be for: leafc, frootc, gresp, live_stemc, dead_stemc, live_crootc, dead_crootc
+                    // if (command_line[0].verbose_flag == -7) {
+                    //     printf("Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_C_pool);
+                    // }
+
+                    // Repeat for nitrogen
+                    patch[0].ash_N_pool += fmax(0.0, (canopy_target[0].ns.leafn * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].ns.frootn * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].ns.live_stemn * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].ns.dead_stemn * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].ns.npool * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].ns.live_crootn * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                                                         (canopy_target[0].ns.dead_crootn * canopy_target[0].fe.canopy_target_prop_c_consumed));
+                    // if (command_line[0].verbose_flag == -7) {
+                    //     printf("Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_N_pool);
+                    //     printf("\n");
+                    // }
+                }
 
                 //printf("strataID:%d\tcanopy_target_prop_c_consumed:%f canopy_target_prop_mort:%lf canopy_target_prop_mort_consumed:%lf\n"
                 //       ,canopy_target[0].ID, canopy_target[0].fe.canopy_target_prop_c_consumed

--- a/rhessys/cn/compute_fire_effects.c
+++ b/rhessys/cn/compute_fire_effects.c
@@ -92,6 +92,13 @@ void compute_fire_effects(
                                                                                 //1: Use predefined mortality rate and consumption rates from command line
                                                                                 //
     struct fire_litter_soil_loss_struct temp_fire_loss = fire_loss;
+    
+    double combust_remain_pct;
+
+	if (command_line[0].ash_deposition_flag == 1){
+		// Assume combustion completeness is 85% for now, can parameterize later
+		combust_remain_pct = 0.15; //inverse of combustion completeness
+	}
 
     //Option for handling fire event
     if (command_line[0].user_defined_fire_event_flag &&
@@ -163,18 +170,19 @@ void compute_fire_effects(
 
         if (command_line[0].ash_deposition_flag == 1){
 			// if (command_line[0].verbose_flag == -7) {
-			// 	printf("Starting - Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_C_pool);
-			// 	printf("Starting - Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_N_pool);
+			// 	printf("Starting - Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_DOC);
+			// 	printf("Starting - Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_DON);
 			// }
-			patch[0].ash_C_pool += fmax(0.0, litter_c_consumed);
+			patch[0].ash_DOC += fmax(0.0, (litter_c_consumed * combust_remain_pct * patch[0].soil_defaults[0][0].ash_pct_soluble_DOC));
 			// don't need this calculation otherwise, so doing it here for ash dep only
-            patch[0].ash_N_pool += fmax(0.0, patch[0].litter_ns.litr1n * fire_loss.loss_litr1n +
+            patch[0].ash_DON += fmax(0.0, (patch[0].litter_ns.litr1n * fire_loss.loss_litr1n +
                                                  patch[0].litter_ns.litr2n * fire_loss.loss_litr2n +
                                                  patch[0].litter_ns.litr3n * fire_loss.loss_litr3n +
-                                                 patch[0].litter_ns.litr4n * fire_loss.loss_litr4n);
+                                                 patch[0].litter_ns.litr4n * fire_loss.loss_litr4n) * 
+                                                 patch[0].soil_defaults[0][0].ash_pct_soluble_DON);
             // if (command_line[0].verbose_flag == -7) {
-			// 	printf("Litter - Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_C_pool);
-			// 	printf("Litter - Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_N_pool);
+			// 	printf("Litter - Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_DOC);
+			// 	printf("Litter - Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_DON);
 			// }
 		}
 
@@ -316,11 +324,11 @@ void compute_fire_effects(
                 canopy_target[0].ns.cwdn -= canopy_target[0].fe.m_cwdn_to_atmos;
 
                 if (command_line[0].ash_deposition_flag == 1){
-                    patch[0].ash_C_pool += fmax(0.0, canopy_target[0].fe.m_cwdc_to_atmos);
-                    patch[0].ash_N_pool += fmax(0.0, canopy_target[0].fe.m_cwdn_to_atmos);
+                    patch[0].ash_DOC += fmax(0.0, canopy_target[0].fe.m_cwdc_to_atmos * combust_remain_pct * patch[0].soil_defaults[0][0].ash_pct_soluble_DOC);
+                    patch[0].ash_DON += fmax(0.0, canopy_target[0].fe.m_cwdn_to_atmos * patch[0].soil_defaults[0][0].ash_pct_soluble_DON);
                     // if (command_line[0].verbose_flag == -7) {
-                    //     printf("CWD - Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_C_pool);
-                    //     printf("CWD - Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_N_pool);
+                    //     printf("CWD - Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_DOC);
+                    //     printf("CWD - Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_DON);
                     // }
                 }
 
@@ -565,28 +573,30 @@ void compute_fire_effects(
                 /*----------------------------------------------------------------------------------------*/
                 // do this before any changes to the baseline stores
                 if (command_line[0].ash_deposition_flag == 1){
-                    patch[0].ash_C_pool += fmax(0.0, (canopy_target[0].cs.leafc * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                    patch[0].ash_DOC += fmax(0.0, ((canopy_target[0].cs.leafc * canopy_target[0].fe.canopy_target_prop_c_consumed) +
                                                          (canopy_target[0].cs.frootc * canopy_target[0].fe.canopy_target_prop_c_consumed) +
                                                          (canopy_target[0].cs.live_stemc * canopy_target[0].fe.canopy_target_prop_c_consumed) +
                                                          (canopy_target[0].cs.dead_stemc * canopy_target[0].fe.canopy_target_prop_c_consumed) +
                                                          (canopy_target[0].cs.cpool * canopy_target[0].fe.canopy_target_prop_c_consumed) +
                                                          (canopy_target[0].cs.live_crootc * canopy_target[0].fe.canopy_target_prop_c_consumed) +
-                                                         (canopy_target[0].cs.dead_crootc * canopy_target[0].fe.canopy_target_prop_c_consumed));
+                                                         (canopy_target[0].cs.dead_crootc * canopy_target[0].fe.canopy_target_prop_c_consumed)) * 
+                                                         combust_remain_pct * patch[0].soil_defaults[0][0].ash_pct_soluble_DOC);
                     // Could include stores+transfers - if adding, it would be for: leafc, frootc, gresp, live_stemc, dead_stemc, live_crootc, dead_crootc
                     // if (command_line[0].verbose_flag == -7) {
-                    //     printf("Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_C_pool);
+                    //     printf("Ash C pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_DOC);
                     // }
 
                     // Repeat for nitrogen
-                    patch[0].ash_N_pool += fmax(0.0, (canopy_target[0].ns.leafn * canopy_target[0].fe.canopy_target_prop_c_consumed) +
+                    patch[0].ash_DON += fmax(0.0, ((canopy_target[0].ns.leafn * canopy_target[0].fe.canopy_target_prop_c_consumed) +
                                                          (canopy_target[0].ns.frootn * canopy_target[0].fe.canopy_target_prop_c_consumed) +
                                                          (canopy_target[0].ns.live_stemn * canopy_target[0].fe.canopy_target_prop_c_consumed) +
                                                          (canopy_target[0].ns.dead_stemn * canopy_target[0].fe.canopy_target_prop_c_consumed) +
                                                          (canopy_target[0].ns.npool * canopy_target[0].fe.canopy_target_prop_c_consumed) +
                                                          (canopy_target[0].ns.live_crootn * canopy_target[0].fe.canopy_target_prop_c_consumed) +
-                                                         (canopy_target[0].ns.dead_crootn * canopy_target[0].fe.canopy_target_prop_c_consumed));
+                                                         (canopy_target[0].ns.dead_crootn * canopy_target[0].fe.canopy_target_prop_c_consumed)) * 
+                                                         patch[0].soil_defaults[0][0].ash_pct_soluble_DON);
                     // if (command_line[0].verbose_flag == -7) {
-                    //     printf("Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_N_pool);
+                    //     printf("Ash N pool for patch %d is now %lf\n", patch[0].ID , patch[0].ash_DON);
                     //     printf("\n");
                     // }
                 }

--- a/rhessys/cycle/patch_daily_F.c
+++ b/rhessys/cycle/patch_daily_F.c
@@ -2348,25 +2348,23 @@ void        patch_daily_F(
                  patch[0].ndf.do_litr4n_loss);
         }
 
-        // Ash deposition and transfer to surface DOC/DON
+		// Ash deposition and transfer to surface DOC/DON
 		if (command_line[0].ash_deposition_flag == 1){
 			// Ash C to Soluble C (DOC) - 0.1 t0 0.01
 			// Only transfer above ZERO
-			if (patch[0].ash_C_pool > ZERO && patch[0].soil_defaults[0][0].ash_transfer_pct > 0 && patch[0].soil_defaults[0][0].ash_pct_soluble_DOC > 0){
-				ash_c_transfer = patch[0].ash_C_pool * patch[0].soil_defaults[0][0].ash_transfer_pct;
-				ash_doc_to_surface = ash_c_transfer * patch[0].soil_defaults[0][0].ash_pct_soluble_DOC;
-				patch[0].ash_C_pool -= ash_c_transfer;
-				patch[0].surface_DOC += ash_doc_to_surface;
+			if (patch[0].ash_DOC > ZERO && patch[0].soil_defaults[0][0].ash_transfer_pct > 0){
+				ash_c_transfer = patch[0].ash_DOC * patch[0].soil_defaults[0][0].ash_transfer_pct;
+				patch[0].ash_DOC -= ash_c_transfer;
+				patch[0].surface_DOC += ash_c_transfer;
 
 				// add transport to outlet stream DOC - LATER
 				// hillslope[0].streamflow_DOC
 			}
-			if (patch[0].ash_N_pool > ZERO && patch[0].soil_defaults[0][0].ash_transfer_pct > 0 && patch[0].soil_defaults[0][0].ash_pct_soluble_DON > 0){
+			if (patch[0].ash_DON > ZERO && patch[0].soil_defaults[0][0].ash_transfer_pct > 0){
 				// Ash N to Soluble N (DON) - 0.01,as a percent of total ash N is hard to calculate 
-				ash_n_transfer = patch[0].ash_N_pool * patch[0].soil_defaults[0][0].ash_transfer_pct;
-				ash_don_to_surface = ash_n_transfer * patch[0].soil_defaults[0][0].ash_pct_soluble_DON;
-				patch[0].ash_N_pool -= ash_n_transfer;
-				patch[0].surface_DON += ash_don_to_surface;
+				ash_n_transfer = patch[0].ash_DON * patch[0].soil_defaults[0][0].ash_transfer_pct;
+				patch[0].ash_DON -= ash_n_transfer;
+				patch[0].surface_DON += ash_n_transfer;
 
 				// add transport to outlet stream DON - LATER
 				// hillslope[0].streamflow_DON

--- a/rhessys/cycle/patch_daily_F.c
+++ b/rhessys/cycle/patch_daily_F.c
@@ -440,6 +440,8 @@ void        patch_daily_F(
     double PAR_direct_covered, PAR_diffuse_covered, PAR_direct_exposed, PAR_diffuse_exposed;
     double snow_melt_covered, snow_melt_exposed;
     double     rz_drainage,unsat_drainage;
+  	double ash_c_transfer, ash_doc_to_surface;
+	double ash_n_transfer, ash_don_to_surface;
     struct    canopy_strata_object    *strata;
     struct    litter_object    *litter;
     struct  dated_sequence    clim_event;
@@ -2345,6 +2347,31 @@ void        patch_daily_F(
         patch[0].surface_DON += (patch[0].ndf.do_litr1n_loss + patch[0].ndf.do_litr2n_loss + patch[0].ndf.do_litr3n_loss +
                  patch[0].ndf.do_litr4n_loss);
         }
+
+        // Ash deposition and transfer to surface DOC/DON
+		if (command_line[0].ash_deposition_flag == 1){
+			// Ash C to Soluble C (DOC) - 0.1 t0 0.01
+			// Only transfer above ZERO
+			if (patch[0].ash_C_pool > ZERO && patch[0].soil_defaults[0][0].ash_transfer_pct > 0 && patch[0].soil_defaults[0][0].ash_pct_soluble_DOC > 0){
+				ash_c_transfer = patch[0].ash_C_pool * patch[0].soil_defaults[0][0].ash_transfer_pct;
+				ash_doc_to_surface = ash_c_transfer * patch[0].soil_defaults[0][0].ash_pct_soluble_DOC;
+				patch[0].ash_C_pool -= ash_c_transfer;
+				patch[0].surface_DOC += ash_doc_to_surface;
+
+				// add transport to outlet stream DOC - LATER
+				// hillslope[0].streamflow_DOC
+			}
+			if (patch[0].ash_N_pool > ZERO && patch[0].soil_defaults[0][0].ash_transfer_pct > 0 && patch[0].soil_defaults[0][0].ash_pct_soluble_DON > 0){
+				// Ash N to Soluble N (DON) - 0.01,as a percent of total ash N is hard to calculate 
+				ash_n_transfer = patch[0].ash_N_pool * patch[0].soil_defaults[0][0].ash_transfer_pct;
+				ash_don_to_surface = ash_n_transfer * patch[0].soil_defaults[0][0].ash_pct_soluble_DON;
+				patch[0].ash_N_pool -= ash_n_transfer;
+				patch[0].surface_DON += ash_don_to_surface;
+
+				// add transport to outlet stream DON - LATER
+				// hillslope[0].streamflow_DON
+			}
+		} // END ash_deposition_flag
 
         if ( update_nitrif(
             &(patch[0].soil_cs),

--- a/rhessys/include/rhessys.h
+++ b/rhessys/include/rhessys.h
@@ -1469,8 +1469,8 @@ struct	soil_default
     int decom_model; /* 1 is rhessys default, 2 is FireBGCv2 and 3 is LandClim*/
     int m_CO2_effect; // should include CO2
     double  ash_transfer_pct;				/* % of ash C available to surface */
-    double  ash_pct_soluble_DOC;				/* % of available ash C pool that is soluble C*/
-    double  ash_pct_soluble_DON;				/* % of available ash N pool that is soluble N*/
+    double  ash_pct_soluble_DOC;				/* % of available ash C pool that is DOC*/
+    double  ash_pct_soluble_DON;				/* % of available ash N pool that is DON*/
 
     struct soil_loopup_table *soil_lookup;
     };
@@ -2108,8 +2108,8 @@ struct patch_object
         double  nitrogen_balance;               /* kgC/m2 */
         double  satzone_nitrate;                /* kgN/m2 saturated zone */
 
-        double  ash_C_pool;                     /* kgC/m2 lost in fire */
-        double  ash_N_pool;                     /* kgN/m2 lost in fire */
+        double  ash_DOC;                     /* kgC/m2 lost in fire */
+        double  ash_DON;                     /* kgN/m2 lost in fire */
 
         struct  soil_c_object   soil_cs;
         struct  soil_n_object   soil_ns;

--- a/rhessys/include/rhessys.h
+++ b/rhessys/include/rhessys.h
@@ -1468,6 +1468,9 @@ struct	soil_default
     struct soil_class	soil_type;
     int decom_model; /* 1 is rhessys default, 2 is FireBGCv2 and 3 is LandClim*/
     int m_CO2_effect; // should include CO2
+    double  ash_transfer_pct;				/* % of ash C available to surface */
+    double  ash_pct_soluble_DOC;				/* % of available ash C pool that is soluble C*/
+    double  ash_pct_soluble_DON;				/* % of available ash N pool that is soluble N*/
 
     struct soil_loopup_table *soil_lookup;
     };
@@ -2105,6 +2108,9 @@ struct patch_object
         double  nitrogen_balance;               /* kgC/m2 */
         double  satzone_nitrate;                /* kgN/m2 saturated zone */
 
+        double  ash_C_pool;                     /* kgC/m2 lost in fire */
+        double  ash_N_pool;                     /* kgN/m2 lost in fire */
+
         struct  soil_c_object   soil_cs;
         struct  soil_n_object   soil_ns;
         struct  litter_object   litter;
@@ -2385,6 +2391,7 @@ struct  command_line_object
         int             fire_spin_period;                                       //years per spin (weather start from first year)
         int             fire_spins;                                             //number of spins
         double          N_decayrate;                                            //N decay rate along soil profile
+        int             ash_deposition_flag; 
 
         char    *output_prefix;
         char    routing_filename[FILEPATH_LEN];

--- a/rhessys/init/construct_command_line.c
+++ b/rhessys/init/construct_command_line.c
@@ -1356,6 +1356,15 @@ struct	command_line_object	*construct_command_line(
 				//printf("\n Read in CO2 data when the climate data is netcdf file");
 				command_line[0].CO2_flag = 1;
 			}/* end if */
+
+			/*--------------------------------------------------------------*/
+			/*		Check for ash deposition flag next.						*/
+			/*--------------------------------------------------------------*/
+			else if (strcmp(main_argv[i],"-ash_deposition") == 0 ){
+				command_line[0].ash_deposition_flag = 1;
+				i++;
+			}
+
 			/*--------------------------------------------------------------*/
 			/*	NOTE:  ADD MORE OPTION PARSING HERE.						*/
 			/*--------------------------------------------------------------*/

--- a/rhessys/init/construct_patch.c
+++ b/rhessys/init/construct_patch.c
@@ -255,8 +255,8 @@ struct patch_object *construct_patch(
     patch[0].soil_ns.DON = 0.0;
     patch[0].soil_cs.DOC = 0.0;
 
-   	patch[0].ash_C_pool = 0.0; //
-	patch[0].ash_N_pool = 0.0;
+   	patch[0].ash_DOC = 0.0; //
+	patch[0].ash_DON = 0.0;
 
     /*--------------------------------------------------------------*/
     /*      initialize accumulator variables for this patch         */

--- a/rhessys/init/construct_patch.c
+++ b/rhessys/init/construct_patch.c
@@ -227,6 +227,10 @@ struct patch_object *construct_patch(
               getDoubleWorldfile(&paramCnt,&paramPtr,"soil_cs.soil3c","%lf",0.0,1);
     patch[0].soil_cs.soil4c =
               getDoubleWorldfile(&paramCnt,&paramPtr,"soil_cs.soil4c","%lf",0.0,1);
+    patch[0].soil_cs.DOC =
+		      getDoubleWorldfile(&paramCnt,&paramPtr,"soil_cs.DOC","%lf",0.0,1);
+	patch[0].soil_ns.DON =
+		      getDoubleWorldfile(&paramCnt,&paramPtr,"soil_ns.DON","%lf",0.0,1);
     patch[0].num_base_stations =
               getIntWorldfile(&paramCnt,&paramPtr,"n_basestations","%d",0,0);
 
@@ -250,6 +254,9 @@ struct patch_object *construct_patch(
     patch[0].detention_store = 0.0;
     patch[0].soil_ns.DON = 0.0;
     patch[0].soil_cs.DOC = 0.0;
+
+   	patch[0].ash_C_pool = 0.0; //
+	patch[0].ash_N_pool = 0.0;
 
     /*--------------------------------------------------------------*/
     /*      initialize accumulator variables for this patch         */

--- a/rhessys/init/construct_soil_defaults.c
+++ b/rhessys/init/construct_soil_defaults.c
@@ -240,6 +240,11 @@ struct soil_default *construct_soil_defaults(
         defobj[0].interval_size = 		getDoubleParam(&paramCnt, &paramPtr, "interval_size", "%lf", INTERVAL_SIZE, 1);
         defobj[0].decom_model = getIntParam(&paramCnt, &paramPtr, "decom_model", "%d", 1, 1); // 1 is default, 2 is FireBGC 3 is LandClim
 
+		/* Ash deposition  parameters */
+		default_object_list[i].ash_transfer_pct = getDoubleParam(&paramCnt, &paramPtr, "ash_transfer_pct", "%lf", 0.01, 1);
+		default_object_list[i].ash_pct_soluble_DOC = getDoubleParam(&paramCnt, &paramPtr, "ash_pct_soluble_DOC", "%lf", 0.05, 1);
+		default_object_list[i].ash_pct_soluble_DON = getDoubleParam(&paramCnt, &paramPtr, "ash_pct_soluble_DON", "%lf", 0.05, 1);
+
 		/*--------------------------------------------------------------*/
 		/* sensitivity adjustment of vertical drainage  soil paramters	*/
 		/* an  scale Pore size index and psi air entry or other parameters	*/


### PR DESCRIPTION
Second version - now does full calculation to DOC in the fire effects.c, so the ash DOC is only actual DOC values. Combustion completeness is currently hardcoded into fire effects code, but could be parameterized - is currently set at 85%. 

AI summary:

This pull request introduces support for simulating ash deposition and its effects following fire events in RHESSys. The main changes add new flags, state variables, and calculations to track ash-derived carbon (DOC) and nitrogen (DON) pools, their transfer to surface pools, and related soil parameters. These enhancements allow for more realistic modeling of post-fire biogeochemical cycling.

**Major changes:**

**Ash deposition modeling:**
- Added a new command-line flag (`-ash_deposition`) to enable ash deposition calculations, and associated logic to parse and set this flag in `command_line_object` and its constructor (`construct_command_line`). [[1]](diffhunk://#diff-7cc5c27a5ae0ab367829b6659c486a1449b24ce491a782da3c619455f870f6c8R2394) [[2]](diffhunk://#diff-e3d0627dcd3ec7947a35244009fa511696807a7e23769478b0fd73bea6c37cdfR1359-R1367)
- Introduced new patch-level state variables `ash_DOC` and `ash_DON` to track fire-derived ash carbon and nitrogen pools, with initialization in both the patch object and its constructor. [[1]](diffhunk://#diff-7cc5c27a5ae0ab367829b6659c486a1449b24ce491a782da3c619455f870f6c8R2111-R2113) [[2]](diffhunk://#diff-47bd3125a60199bb3287ecb4ef2917269db257b11ef362b769d063fab05fb1b1R258-R260)

**Fire effects and ash pool updates:**
- Updated `compute_fire_effects` to calculate and add ash DOC and DON to patch pools during fire events, using soil parameters for soluble fractions and a combustion completeness assumption. This includes contributions from litter, coarse woody debris, and canopy components. [[1]](diffhunk://#diff-e5dac166e2462b0d11c3dec5f67dad899ebdfdfb821f19a756b1c4b1f9910299R96-R102) [[2]](diffhunk://#diff-e5dac166e2462b0d11c3dec5f67dad899ebdfdfb821f19a756b1c4b1f9910299R171-R188) [[3]](diffhunk://#diff-e5dac166e2462b0d11c3dec5f67dad899ebdfdfb821f19a756b1c4b1f9910299R326-R333) [[4]](diffhunk://#diff-e5dac166e2462b0d11c3dec5f67dad899ebdfdfb821f19a756b1c4b1f9910299R571-R602)

**Ash transfer to surface pools:**
- In `patch_daily_F`, implemented logic to transfer a fraction of patch ash DOC and DON to surface DOC/DON pools each day, based on new soil default parameters. [[1]](diffhunk://#diff-ad8daa3396bf263ed5d0c9ad4a75d13ac89168fe7d921a9399a27697c080d487R2351-R2373) [[2]](diffhunk://#diff-ad8daa3396bf263ed5d0c9ad4a75d13ac89168fe7d921a9399a27697c080d487R443-R444)

**Soil and patch initialization:**
- Added new soil default parameters (`ash_transfer_pct`, `ash_pct_soluble_DOC`, `ash_pct_soluble_DON`) to control ash pool behavior, with parsing and initialization in both the header and constructor. [[1]](diffhunk://#diff-7cc5c27a5ae0ab367829b6659c486a1449b24ce491a782da3c619455f870f6c8R1471-R1473) [[2]](diffhunk://#diff-5fb0b325a0ab489daa237a4208ae5fec2a43f1b6653e31cf74ecb5d6594d368eR243-R247)
- Ensured patch and soil DOC/DON pools are correctly initialized from worldfiles in the patch constructor.